### PR TITLE
Fix possible error in sample documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ new BitPayAndroid.CreateInvoiceTask(bitpay) {
 
 #### Using promises
 ```java
-bitpay.createInvoice(new Invoice(200, "USD")).then(new InvoicePromiseCallback() {
+bitpay.createNewInvoice(new Invoice(200, "USD")).then(new InvoicePromiseCallback() {
 
     public void onSuccess(Invoice invoice) {
         // ...


### PR DESCRIPTION
Trying to use the sample for creating an invoice with promises I found out that bitpay.createInvoice does not return a promise object and throws an exception, therefore the .then() function does not exist

Instead I found searching through the code the bitpay.createNewInvoice() that indeed returns a promise object.